### PR TITLE
Add namespace for multiproject support

### DIFF
--- a/.github/workflows/azure-static-web-apps-agreeable-field-042a6af03.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-field-042a6af03.yml
@@ -1,9 +1,9 @@
 name: Azure Static Web Apps CI/CD
 
 on:
-  push:
-    branches:
-      - main
+#  push:
+#    branches:
+#      - main
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "license": "LGPL-3.0",
     "dependencies": {
         "@tsconfig/svelte": "^3.0.0",
+        "dexie": "^3.2.2",
         "svelte": "^3.50.1"
     },
     "devDependencies": {

--- a/src/logic/__fixtures__/timelog-entries.ts
+++ b/src/logic/__fixtures__/timelog-entries.ts
@@ -1,44 +1,51 @@
+import { defaultNamespace, defaultTask } from "../../types";
+import { TimelogEntry } from "../types";
+
 export const FIRST_START_ENTRY = {
     logId: "7e2b07d2-a090-4474-aeb3-a6a3e3ba6ac1",
     logTime: 1663942832356,
     logType: "start",
     task: "sample task",
-};
+    namespace: defaultNamespace,
+} as TimelogEntry;
 export const FIRST_END_ENTRY = {
     logId: "134c73dd-2568-41e9-be08-96a068f938d6",
     logTime: 1663942979608,
     logType: "end",
-};
+} as TimelogEntry;
 export const SECOND_START_ENTRY = {
     logId: "3e06be87-7163-439a-8693-ca94c1549f30",
     logTime: 1663945172232,
     logType: "start",
     task: "sample task",
-};
+    namespace: defaultNamespace,
+} as TimelogEntry;
 export const SECOND_END_ENTRY = {
     logId: "e051775a-9845-4f58-adef-36f65b44f70c",
     logTime: 1663946177983,
     logType: "end",
-};
+} as TimelogEntry;
 export const THIRD_START_ENTRY = {
     logId: "e7dc97d6-c8fd-45d2-b9b6-c221685f6d65",
     logTime: 1663948849344,
     logType: "start",
-    task: undefined,
-};
+    task: defaultTask,
+    namespace: defaultNamespace,
+} as TimelogEntry;
 export const THIRD_END_ENTRY = {
     logId: "e4ec6e3a-ef35-496e-a814-a84cbed595a4",
     logTime: 1663950762397,
     logType: "end",
-};
+} as TimelogEntry;
 export const FOURTH_START_ENTRY = {
     logId: "c4cb2936-dd51-496d-941b-76713ffbbba4",
     logTime: 1663950762398,
     logType: "start",
-    task: undefined,
-};
+    task: defaultTask,
+    namespace: defaultNamespace,
+} as TimelogEntry;
 export const FOURTH_END_ENTRY = {
     logId: "8f874dca-6848-4d55-87ba-8cda8daa4b52",
     logTime: 1663950762499,
     logType: "end",
-};
+} as TimelogEntry;

--- a/src/logic/__fixtures__/timelogs.ts
+++ b/src/logic/__fixtures__/timelogs.ts
@@ -1,14 +1,18 @@
+import { defaultNamespace, defaultTask } from "../../types";
+
 export const FIRST_FULL_TIMELOG = {
     logId: "7e2b07d2-a090-4474-aeb3-a6a3e3ba6ac1",
     closingLogId: "134c73dd-2568-41e9-be08-96a068f938d6",
     startTime: 1663942832356,
     endTime: 1663942979608,
     task: "sample task",
+    namespace: defaultNamespace,
 };
 export const FIRST_START_TIMELOG = {
     logId: "7e2b07d2-a090-4474-aeb3-a6a3e3ba6ac1",
     startTime: 1663942832356,
     task: "sample task",
+    namespace: defaultNamespace,
 };
 export const SECOND_FULL_TIMELOG = {
     logId: "3e06be87-7163-439a-8693-ca94c1549f30",
@@ -16,35 +20,41 @@ export const SECOND_FULL_TIMELOG = {
     startTime: 1663945172232,
     endTime: 1663946177983,
     task: "sample task",
+    namespace: defaultNamespace,
 };
 export const SECOND_START_TIMELOG = {
     logId: "3e06be87-7163-439a-8693-ca94c1549f30",
     startTime: 1663945172232,
     task: "sample task",
+    namespace: defaultNamespace,
 };
 export const THIRD_FULL_TIMELOG = {
     logId: "e7dc97d6-c8fd-45d2-b9b6-c221685f6d65",
     closingLogId: "e4ec6e3a-ef35-496e-a814-a84cbed595a4",
     startTime: 1663948849344,
     endTime: 1663950762397,
-    task: undefined,
+    task: defaultTask,
+    namespace: defaultNamespace,
 };
 export const THIRD_START_TIMELOG = {
     logId: "e7dc97d6-c8fd-45d2-b9b6-c221685f6d65",
     startTime: 1663948849344,
-    task: undefined,
+    task: defaultTask,
+    namespace: defaultNamespace,
 };
 export const FOURTH_FULL_TIMELOG = {
     logId: "c4cb2936-dd51-496d-941b-76713ffbbba4",
     closingLogId: "8f874dca-6848-4d55-87ba-8cda8daa4b52",
     startTime: 1663950762398,
     endTime: 1663950762499,
-    task: undefined,
+    task: defaultTask,
+    namespace: defaultNamespace,
 };
 export const FOURTH_START_TIMELOG = {
     logId: "c4cb2936-dd51-496d-941b-76713ffbbba4",
     startTime: 1663950762398,
-    task: undefined,
+    task: defaultTask,
+    namespace: defaultNamespace,
 };
 export const FIFTH_FULL_TIMELOG = {
     logId: "e4404211-30d9-465f-8daa-e883fc1a49f5",
@@ -52,6 +62,7 @@ export const FIFTH_FULL_TIMELOG = {
     startTime: 1668946462050,
     endTime: 1668946559996,
     task: "sample task",
+    namespace: defaultNamespace,
 };
 export const SIXTH_FULL_TIMELOG = {
     logId: "1ba186d7-a468-4f2b-84a6-561ed4bf2039",
@@ -59,6 +70,7 @@ export const SIXTH_FULL_TIMELOG = {
     startTime: 1668946808744,
     endTime: 1668947439513,
     task: "sample2 task",
+    namespace: defaultNamespace,
 };
 export const MORE_THAN_WORKDAY_TIMELOG = {
     logId: "e699cb3e-11c7-4edf-b1f3-daae729bd50c",
@@ -66,4 +78,5 @@ export const MORE_THAN_WORKDAY_TIMELOG = {
     startTime: 1641023104000,
     endTime: 1641057340000,
     task: "sample giant task",
+    namespace: defaultNamespace,
 };

--- a/src/logic/persistent-store/mock-binding.ts
+++ b/src/logic/persistent-store/mock-binding.ts
@@ -1,0 +1,7 @@
+import { TimeasrStoreBinding } from "../types";
+
+export const MockBinding: TimeasrStoreBinding = {
+    initializeDB: () => Promise.resolve(),
+    getTimelogEntries: () => Promise.resolve([]),
+    persistTimelogEntry: (entry) => Promise.resolve(entry.logId),
+};

--- a/src/logic/persistent-store/timeasr-store-dexie-binding.ts
+++ b/src/logic/persistent-store/timeasr-store-dexie-binding.ts
@@ -1,0 +1,42 @@
+import Dexie from "dexie";
+import { defaultNamespace, defaultTask } from "../../types";
+import { SETTING_ENTRY_KEY_NAME, TimeasrStoreBinding, TIMELOG_ENTRY_KEY_NAME, TIMELOG_ENTRY_TIME_NAME, TimelogEntry } from "../types";
+import { DB_NAME, DB_STORE_SETTINGS, DB_STORE_TIMELOG } from "./types";
+
+let db: Dexie;
+
+const initializeDB = async () => {
+    db = new Dexie(DB_NAME);
+    db.version(0.3).stores({
+        [DB_STORE_TIMELOG]: `${TIMELOG_ENTRY_KEY_NAME},&${TIMELOG_ENTRY_TIME_NAME}`,
+        [DB_STORE_SETTINGS]: SETTING_ENTRY_KEY_NAME,
+    });
+    db.version(0.4).stores({
+        [DB_STORE_TIMELOG]: `${TIMELOG_ENTRY_KEY_NAME},&${TIMELOG_ENTRY_TIME_NAME}`,
+        [DB_STORE_SETTINGS]: SETTING_ENTRY_KEY_NAME,
+    }).upgrade((trans) => {
+        trans.table(DB_STORE_TIMELOG).toCollection().modify((timelogEntry) => {
+            if (timelogEntry.logType === "start" && !timelogEntry.namespace) {
+                timelogEntry.namespace = defaultNamespace;
+            }
+            if (timelogEntry.logType === "start" && !timelogEntry.task) {
+                timelogEntry.task = defaultTask;
+            }
+        });
+    });
+};
+
+const getTimelogEntries = async () => {
+    return db.table(DB_STORE_TIMELOG).orderBy("logTime").reverse().toArray();
+};
+
+const persistTimelogEntry = async (timelogEntry: TimelogEntry) => {
+    await db.table(DB_STORE_TIMELOG).add(timelogEntry);
+    return timelogEntry.logId;
+};
+
+export const DexieBinding: TimeasrStoreBinding = {
+    initializeDB,
+    getTimelogEntries,
+    persistTimelogEntry,
+};

--- a/src/logic/persistent-store/types.ts
+++ b/src/logic/persistent-store/types.ts
@@ -26,3 +26,8 @@ export type QueryParams<Data, Result> = {
 export type RunQueryFn<Data, Result> = {
     (params: QueryParams<Data, Result>): Promise<Result>;
 };
+
+export const DB_NAME = "timeasr-db";
+export const DB_STORE_BYTIME_INDEX = "by-time-index";
+export const DB_STORE_SETTINGS = "settings";
+export const DB_STORE_TIMELOG = "timelog";

--- a/src/logic/timeasr-store.test.ts
+++ b/src/logic/timeasr-store.test.ts
@@ -1,139 +1,145 @@
-import { IndexedDbMocker } from "./persistent-store/indexed-db.mock";
-
-import { DB_CONFIG } from "./types";
-import { FIRST_END_ENTRY, FIRST_FULL_TIMELOG, FIRST_START_ENTRY, FIRST_START_TIMELOG, FOURTH_START_ENTRY, FOURTH_START_TIMELOG, SECOND_END_ENTRY, SECOND_FULL_TIMELOG, SECOND_START_ENTRY, SECOND_START_TIMELOG, THIRD_END_ENTRY, THIRD_START_ENTRY, THIRD_START_TIMELOG } from "./__fixtures__/all-fixtures";
+import {
+    FIRST_END_ENTRY,
+    FIRST_FULL_TIMELOG,
+    FIRST_START_ENTRY,
+    FIRST_START_TIMELOG,
+    FOURTH_START_ENTRY,
+    FOURTH_START_TIMELOG,
+    SECOND_END_ENTRY,
+    SECOND_FULL_TIMELOG,
+    SECOND_START_ENTRY,
+    SECOND_START_TIMELOG,
+    THIRD_END_ENTRY,
+    THIRD_START_ENTRY,
+    THIRD_START_TIMELOG,
+} from "./__fixtures__/all-fixtures";
+import { MockBinding } from "./persistent-store/mock-binding";
 import { TimeasrStore } from "./timeasr-store";
 import * as BrowserWrapper from "./browser-wrapper";
 
 describe("Timeasr Store", () => {
     afterEach(() => {
-        IndexedDbMocker.reset();
+        jest.restoreAllMocks();
     });
-    it("initialize() sets the proper database configuration", async () => {
-        await TimeasrStore.initialize();
-        expect(IndexedDbMocker.getDatabaseConfig()).toStrictEqual(DB_CONFIG);
+    test("initialize() sets the proper database configuration", async () => {
+        const bindingInitFn = jest.spyOn(MockBinding, "initializeDB");
+        await TimeasrStore.initialize(MockBinding);
+        expect(bindingInitFn).toHaveBeenCalledTimes(1);
     });
     describe("getLastTimelog()", () => {
-        it("returns null - if no log exists yet", async () => {
-            IndexedDbMocker.setRunQueryFn(() => Promise.resolve([]));
-            await TimeasrStore.initialize();
+        test("returns null - if no log exists yet", async () => {
+            await TimeasrStore.initialize(MockBinding);
             return expect(TimeasrStore.getLastTimelog()).toBeNull();
         });
-        it("returns the last timelog - if it is full timelog", async () => {
-            IndexedDbMocker.setRunQueryFn(() => Promise.resolve([FIRST_END_ENTRY, FIRST_START_ENTRY]));
-            await TimeasrStore.initialize();
+        test("returns the last timelog - if it is full timelog", async () => {
+            jest.spyOn(MockBinding, "getTimelogEntries").mockResolvedValue([FIRST_END_ENTRY, FIRST_START_ENTRY]);
+            await TimeasrStore.initialize(MockBinding);
             return expect(TimeasrStore.getLastTimelog()).toStrictEqual(FIRST_FULL_TIMELOG);
         });
-        it("returns the last timelog - if it is started timelog", async () => {
-            IndexedDbMocker.setRunQueryFn(() => Promise.resolve([FIRST_START_ENTRY]));
-            await TimeasrStore.initialize();
+        test("returns the last timelog - if it is started timelog", async () => {
+            jest.spyOn(MockBinding, "getTimelogEntries").mockResolvedValue([FIRST_START_ENTRY]);
+            await TimeasrStore.initialize(MockBinding);
             return expect(TimeasrStore.getLastTimelog()).toStrictEqual(FIRST_START_TIMELOG);
         });
     });
     describe("getTimelogsOfPeriod()", () => {
-        it("returns empty array - if it is requested from the beginning of time and there are no logs", async () => {
-            IndexedDbMocker.setRunQueryFn(() => Promise.resolve([]));
-            await TimeasrStore.initialize();
+        test("returns empty array - if it is requested from the beginning of time and there are no logs", async () => {
+            await TimeasrStore.initialize(MockBinding);
             return expect(TimeasrStore.getTimelogsOfPeriod(0)).toStrictEqual([]);
         });
-        it("returns empty array - if no logs are existing for the specified period", async () => {
-            IndexedDbMocker.setRunQueryFn(() =>
-                Promise.resolve([SECOND_START_ENTRY, FIRST_END_ENTRY, FIRST_START_ENTRY])
-            );
-            await TimeasrStore.initialize();
+        test("returns empty array - if no logs are existing for the specified period", async () => {
+            jest.spyOn(MockBinding, "getTimelogEntries").mockResolvedValue([
+                SECOND_START_ENTRY,
+                FIRST_END_ENTRY,
+                FIRST_START_ENTRY,
+            ]);
+            await TimeasrStore.initialize(MockBinding);
             return expect(TimeasrStore.getTimelogsOfPeriod(1663948849344, 1663950860047)).toStrictEqual([]);
         });
-        it("returns all timelogs - if it is requested from the beginning of time and logs are existing", async () => {
-            IndexedDbMocker.setRunQueryFn(() =>
-                Promise.resolve([SECOND_START_ENTRY, FIRST_END_ENTRY, FIRST_START_ENTRY])
-            );
-            await TimeasrStore.initialize();
+        test("returns all timelogs - if it is requested from the beginning of time and logs are existing", async () => {
+            jest.spyOn(MockBinding, "getTimelogEntries").mockResolvedValue([
+                SECOND_START_ENTRY,
+                FIRST_END_ENTRY,
+                FIRST_START_ENTRY,
+            ]);
+            await TimeasrStore.initialize(MockBinding);
             return expect(TimeasrStore.getTimelogsOfPeriod(0)).toStrictEqual([
                 SECOND_START_TIMELOG,
                 FIRST_FULL_TIMELOG,
             ]);
         });
-        it("returns timelogs for selected period (if period include whole timelog)", async () => {
-            IndexedDbMocker.setRunQueryFn(() =>
-                Promise.resolve([
-                    THIRD_END_ENTRY,
-                    THIRD_START_ENTRY,
-                    SECOND_END_ENTRY,
-                    SECOND_START_ENTRY,
-                    FIRST_END_ENTRY,
-                    FIRST_START_ENTRY,
-                ])
-            );
-            await TimeasrStore.initialize();
+        test("returns timelogs for selected period (if period include whole timelog)", async () => {
+            jest.spyOn(MockBinding, "getTimelogEntries").mockResolvedValue([
+                THIRD_END_ENTRY,
+                THIRD_START_ENTRY,
+                SECOND_END_ENTRY,
+                SECOND_START_ENTRY,
+                FIRST_END_ENTRY,
+                FIRST_START_ENTRY,
+            ]);
+            await TimeasrStore.initialize(MockBinding);
             return expect(TimeasrStore.getTimelogsOfPeriod(1663945172232, 1663946177983)).toStrictEqual([
                 SECOND_FULL_TIMELOG,
             ]);
         });
-        it("returns timelogs for selected period (if period start overlaps with timelog)", async () => {
-            IndexedDbMocker.setRunQueryFn(() =>
-                Promise.resolve([
-                    THIRD_END_ENTRY,
-                    THIRD_START_ENTRY,
-                    SECOND_END_ENTRY,
-                    SECOND_START_ENTRY,
-                    FIRST_END_ENTRY,
-                    FIRST_START_ENTRY,
-                ])
-            );
-            await TimeasrStore.initialize();
+        test("returns timelogs for selected period (if period start overlaps with timelog)", async () => {
+            jest.spyOn(MockBinding, "getTimelogEntries").mockResolvedValue([
+                THIRD_END_ENTRY,
+                THIRD_START_ENTRY,
+                SECOND_END_ENTRY,
+                SECOND_START_ENTRY,
+                FIRST_END_ENTRY,
+                FIRST_START_ENTRY,
+            ]);
+            await TimeasrStore.initialize(MockBinding);
             return expect(TimeasrStore.getTimelogsOfPeriod(1663945172230, 1663945172235)).toStrictEqual([
                 SECOND_FULL_TIMELOG,
             ]);
         });
-        it("returns timelogs for selected period (if period end overlaps with timelog)", async () => {
-            IndexedDbMocker.setRunQueryFn(() =>
-                Promise.resolve([
-                    THIRD_END_ENTRY,
-                    THIRD_START_ENTRY,
-                    SECOND_END_ENTRY,
-                    SECOND_START_ENTRY,
-                    FIRST_END_ENTRY,
-                    FIRST_START_ENTRY,
-                ])
-            );
-            await TimeasrStore.initialize();
+        test("returns timelogs for selected period (if period end overlaps with timelog)", async () => {
+            jest.spyOn(MockBinding, "getTimelogEntries").mockResolvedValue([
+                THIRD_END_ENTRY,
+                THIRD_START_ENTRY,
+                SECOND_END_ENTRY,
+                SECOND_START_ENTRY,
+                FIRST_END_ENTRY,
+                FIRST_START_ENTRY,
+            ]);
+            await TimeasrStore.initialize(MockBinding);
             return expect(TimeasrStore.getTimelogsOfPeriod(1663946177980, 1663946177985)).toStrictEqual([
                 SECOND_FULL_TIMELOG,
             ]);
         });
-        it("returns timelogs for selected period (if period is until now and timelog is running)", async () => {
-            IndexedDbMocker.setRunQueryFn(() =>
-                Promise.resolve([
-                    THIRD_START_ENTRY,
-                    SECOND_END_ENTRY,
-                    SECOND_START_ENTRY,
-                    FIRST_END_ENTRY,
-                    FIRST_START_ENTRY,
-                ])
-            );
+        test("returns timelogs for selected period (if period is until now and timelog is running)", async () => {
+            jest.spyOn(MockBinding, "getTimelogEntries").mockResolvedValue([
+                THIRD_START_ENTRY,
+                SECOND_END_ENTRY,
+                SECOND_START_ENTRY,
+                FIRST_END_ENTRY,
+                FIRST_START_ENTRY,
+            ]);
             jest.spyOn(BrowserWrapper, "now").mockImplementation(() => THIRD_END_ENTRY.logTime);
-            await TimeasrStore.initialize();
+            await TimeasrStore.initialize(MockBinding);
             return expect(TimeasrStore.getTimelogsOfPeriod(THIRD_START_ENTRY.logTime + 1000)).toStrictEqual([
                 THIRD_START_TIMELOG,
             ]);
         });
     });
     describe("startTimelog()", () => {
-        it("creates a start Timelog - if there is no running task", async () => {
-            const runQueryFn = jest.fn().mockImplementation(() => []);
-            IndexedDbMocker.setRunQueryFn(runQueryFn);
+        test("creates a start Timelog - if there is no running task", async () => {
+            const persistTimelogEntryMock = jest.spyOn(MockBinding, "persistTimelogEntry");
             jest.spyOn(BrowserWrapper, "now").mockImplementation(() => SECOND_START_ENTRY.logTime);
             jest.spyOn(BrowserWrapper, "randomUUID").mockImplementation(() => SECOND_START_ENTRY.logId);
 
-            await TimeasrStore.initialize();
+            await TimeasrStore.initialize(MockBinding);
             await TimeasrStore.startTimelog(SECOND_START_ENTRY.task);
-            expect(runQueryFn).toHaveBeenLastCalledWith(expect.objectContaining({ data: SECOND_START_ENTRY }));
+            expect(persistTimelogEntryMock).toHaveBeenLastCalledWith(SECOND_START_ENTRY);
             expect(TimeasrStore.getLastTimelog()).toStrictEqual(SECOND_START_TIMELOG);
         });
-        it("creates a close and start Timelog - if there is a running task", async () => {
+        test("creates a close and start Timelog - if there is a running task", async () => {
             let randomUUIDCallCount = 0;
-            const runQueryFn = jest.fn().mockImplementation(() => [THIRD_START_ENTRY]);
-            IndexedDbMocker.setRunQueryFn(runQueryFn);
+            const persistTimelogEntryMock = jest.spyOn(MockBinding, "persistTimelogEntry");
+            jest.spyOn(MockBinding, "getTimelogEntries").mockResolvedValue([THIRD_START_ENTRY]);
             jest.spyOn(BrowserWrapper, "now").mockImplementation(() => FOURTH_START_ENTRY.logTime);
             jest.spyOn(BrowserWrapper, "randomUUID").mockImplementation(() => {
                 const logIds = [THIRD_END_ENTRY.logId, FOURTH_START_ENTRY.logId];
@@ -142,26 +148,21 @@ describe("Timeasr Store", () => {
                 return currentLogId;
             });
 
-            await TimeasrStore.initialize();
+            await TimeasrStore.initialize(MockBinding);
             await TimeasrStore.startTimelog();
-            expect(runQueryFn).toHaveBeenNthCalledWith(
-                2,
-                expect.objectContaining({
-                    data: THIRD_END_ENTRY,
-                })
-            );
-            expect(runQueryFn).toHaveBeenNthCalledWith(3, expect.objectContaining({ data: FOURTH_START_ENTRY }));
+            expect(persistTimelogEntryMock).toHaveBeenNthCalledWith(1, THIRD_END_ENTRY);
+            expect(persistTimelogEntryMock).toHaveBeenNthCalledWith(2, FOURTH_START_ENTRY);
             expect(TimeasrStore.getLastTimelog()).toStrictEqual(FOURTH_START_TIMELOG);
         });
-        it("creates an end Timelog", async () => {
-            const runQueryFn = jest.fn().mockImplementation(() => [SECOND_START_ENTRY]);
-            IndexedDbMocker.setRunQueryFn(runQueryFn);
+        test("creates an end Timelog", async () => {
+            const persistTimelogEntryMock = jest.spyOn(MockBinding, "persistTimelogEntry");
+            jest.spyOn(MockBinding, "getTimelogEntries").mockResolvedValue([SECOND_START_ENTRY]);
             jest.spyOn(BrowserWrapper, "now").mockImplementation(() => SECOND_END_ENTRY.logTime + 1);
             jest.spyOn(BrowserWrapper, "randomUUID").mockImplementation(() => SECOND_END_ENTRY.logId);
 
-            await TimeasrStore.initialize();
+            await TimeasrStore.initialize(MockBinding);
             await TimeasrStore.closeTimelog();
-            expect(runQueryFn).toHaveBeenLastCalledWith(expect.objectContaining({ data: SECOND_END_ENTRY }));
+            expect(persistTimelogEntryMock).toHaveBeenLastCalledWith(SECOND_END_ENTRY);
             expect(TimeasrStore.getLastTimelog()).toStrictEqual(SECOND_FULL_TIMELOG);
         });
     });

--- a/src/logic/timelog-store-utils.test.ts
+++ b/src/logic/timelog-store-utils.test.ts
@@ -6,48 +6,48 @@ import * as BrowserWrapper from "./browser-wrapper";
 
 describe("Timelog Store utils", () => {
     describe("convertTimelogToTimelogEntry", () => {
-        it("converts full log to start log - with task", () => {
+        test("converts full log to start log - with task", () => {
             expect(convertTimelogToTimelogEntry(FIRST_FULL_TIMELOG, "start")).toStrictEqual(FIRST_START_ENTRY);
         });
-        it("converts full log to start log - without task", () => {
+        test("converts full log to start log - without task", () => {
             expect(convertTimelogToTimelogEntry(THIRD_FULL_TIMELOG, "start")).toStrictEqual(THIRD_START_ENTRY);
         });
-        it("converts full log to start log and extends if there are missing contents", () => {
+        test("converts full log to start log and extends if there are missing contents", () => {
             jest.spyOn(BrowserWrapper, "now").mockImplementation(() => SECOND_START_ENTRY.logTime);
             jest.spyOn(BrowserWrapper, "randomUUID").mockImplementation(() => SECOND_START_ENTRY.logId);
             expect(
                 convertTimelogToTimelogEntry({ task: SECOND_START_ENTRY.task } as FinishedTimelog, "start")
             ).toStrictEqual(SECOND_START_ENTRY);
         });
-        it("converts full log to end log", () => {
+        test("converts full log to end log", () => {
             expect(convertTimelogToTimelogEntry(FIRST_FULL_TIMELOG, "end")).toStrictEqual(FIRST_END_ENTRY);
         });
     });
     describe("parseTimelogEntriesToTimelogs()", () => {
-        it("converts an empty entries list to an empty array", () => {
+        test("converts an empty entries list to an empty array", () => {
             const entries = [] as TimelogEntry[];
             expect(parseTimelogEntriesToTimelogs(entries)).toStrictEqual([] as FinishedTimelog[]);
         });
-        it("converts a single start entry to a single (started) timelog", () => {
+        test("converts a single start entry to a single (started) timelog", () => {
             const entries = [FIRST_START_ENTRY] as TimelogEntry[];
             expect(parseTimelogEntriesToTimelogs(entries)).toStrictEqual([FIRST_START_TIMELOG] as FinishedTimelog[]);
         });
-        it("skips converting a wrong single end entry", () => {
+        test("skips converting a wrong single end entry", () => {
             const entries = [FIRST_END_ENTRY] as TimelogEntry[];
             expect(parseTimelogEntriesToTimelogs(entries)).toStrictEqual([] as FinishedTimelog[]);
         });
-        it("converts a single pair of entries to a single timelog", () => {
+        test("converts a single pair of entries to a single timelog", () => {
             const entries = [FIRST_END_ENTRY, FIRST_START_ENTRY] as TimelogEntry[];
             expect(parseTimelogEntriesToTimelogs(entries)).toStrictEqual([FIRST_FULL_TIMELOG] as FinishedTimelog[]);
         });
-        it("converts three entries (start+end+start) to timelogs", () => {
+        test("converts three entries (start+end+start) to timelogs", () => {
             const entries = [SECOND_START_ENTRY, FIRST_END_ENTRY, FIRST_START_ENTRY] as TimelogEntry[];
             expect(parseTimelogEntriesToTimelogs(entries)).toStrictEqual([
                 SECOND_START_TIMELOG,
                 FIRST_FULL_TIMELOG,
             ] as FinishedTimelog[]);
         });
-        it("converts four valid entries to timelogs", () => {
+        test("converts four valid entries to timelogs", () => {
             const entries = [
                 SECOND_END_ENTRY,
                 SECOND_START_ENTRY,
@@ -59,7 +59,7 @@ describe("Timelog Store utils", () => {
                 FIRST_FULL_TIMELOG,
             ] as FinishedTimelog[]);
         });
-        it("skips converting and invalid entry", () => {
+        test("skips converting and invalid entry", () => {
             const entries = [SECOND_END_ENTRY, FIRST_END_ENTRY, FIRST_START_ENTRY] as TimelogEntry[];
             expect(parseTimelogEntriesToTimelogs(entries)).toStrictEqual([FIRST_FULL_TIMELOG] as FinishedTimelog[]);
         });

--- a/src/logic/types.ts
+++ b/src/logic/types.ts
@@ -1,48 +1,37 @@
-import { DatabaseConfiguration } from "./persistent-store/types";
+import { UUID } from "../types";
 
-const SETTING_ENTRY_KEY_NAME = "settingId";
-const SETTING_ENTRY_TIME_NAME = "settingTime";
-const TIMELOG_ENTRY_KEY_NAME = "logId";
-const TIMELOG_ENTRY_TIME_NAME = "logTime";
-export const DB_STORE_BYTIME_INDEX = "by-time-index";
-export const DB_STORE_SETTINGS = "settings";
-export const DB_STORE_TIMELOG = "timelog";
+export const SETTING_ENTRY_KEY_NAME = "settingId";
+export const SETTING_ENTRY_TIME_NAME = "settingTime";
+export const TIMELOG_ENTRY_KEY_NAME = "logId";
+export const TIMELOG_ENTRY_TIME_NAME = "logTime";
 
 type epoch = number;
 type json = string;
 type LogType = "start" | "end";
-export type TimelogEntry = {
+
+type BasicTimelogEntry = {
     [TIMELOG_ENTRY_KEY_NAME]: string;
     [TIMELOG_ENTRY_TIME_NAME]: epoch;
     logType: LogType;
-    task?: string;
 };
+type StartTimelogEntry = {
+    logType: "start";
+    namespace: string | "default";
+    task: string | "default";
+} & BasicTimelogEntry;
+type EndTimelogEntry = {
+    logType: "end";
+} & BasicTimelogEntry;
+
+export type TimelogEntry = StartTimelogEntry | EndTimelogEntry;
 export type SettingEntry = {
     [SETTING_ENTRY_KEY_NAME]: string;
     [SETTING_ENTRY_TIME_NAME]: epoch;
     value: json;
 };
 
-export const DB_CONFIG: DatabaseConfiguration = {
-    dbName: "timeasr-db",
-    dbVersion: 3,
-    tables: [
-        {
-            tableName: DB_STORE_TIMELOG,
-            keyPath: TIMELOG_ENTRY_KEY_NAME,
-            autoIncrement: false,
-            indices: [
-                {
-                    indexName: DB_STORE_BYTIME_INDEX,
-                    indexPath: TIMELOG_ENTRY_TIME_NAME,
-                    unique: true,
-                },
-            ],
-        },
-        {
-            tableName: DB_STORE_SETTINGS,
-            keyPath: SETTING_ENTRY_KEY_NAME,
-            autoIncrement: false,
-        },
-    ],
+export type TimeasrStoreBinding = {
+    initializeDB: () => Promise<void>;
+    getTimelogEntries: () => Promise<TimelogEntry[]>;
+    persistTimelogEntry: (timelogEntry: TimelogEntry) => Promise<UUID>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,13 @@
 export type UUID = string;
 export type Milliseconds = number;
+export const defaultNamespace = "default";
+export const defaultTask = "default";
+
 export type StartedTimelog = {
     logId: UUID;
     startTime: number;
-    task: string | undefined;
+    task: string | "default";
+    namespace: string | "default";
 };
 export type FinishedTimelog = {
     closingLogId: UUID;
@@ -14,6 +18,7 @@ export type Task = {
     active?: boolean;
     loggedTime: Milliseconds;
     name: string;
+    namespace: string | "default";
 };
 export type Stat = {
     averageTimePerDay: Milliseconds;


### PR DESCRIPTION
- Add Dexie database binding to support database
  upgrade, changes and connection handling easier
- Add mock database binding
- Add new namespace field to Timelog and TimelogEntry
- Add default task and namespace name
- Clean up and reorganize type definitions
- Convert undefined task to default
- Improve business logic unit tests